### PR TITLE
Update Getting Start Ruby SDK to be compatible with 3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ $ git clone https://github.com/smartcar/getting-started-ruby-sdk.git
 $ cd getting-started-ruby-sdk/app
 ```
 
-**Note:** This app was built on ruby 2.7
+**Note:** This app is compatible with 2.7 and above
 
 To install the required dependencies and run this Sinatra app -
 ```bash

--- a/app/Gemfile
+++ b/app/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'sinatra', '>= 2.1.0'
+gem 'sinatra', '>= 2.2.3'
 gem 'smartcar', '>= 3.3.0'
 gem 'thin', '>= 1.8.1'

--- a/app/Gemfile
+++ b/app/Gemfile
@@ -2,3 +2,4 @@ source 'https://rubygems.org'
 
 gem 'sinatra', '>= 2.1.0'
 gem 'smartcar', '>= 3.3.0'
+gem 'thin', '>= 1.8.1'

--- a/app/Gemfile.lock
+++ b/app/Gemfile.lock
@@ -10,7 +10,7 @@ GEM
     jwt (2.4.1)
     multi_json (1.15.0)
     multi_xml (0.6.0)
-    mustermann (1.1.1)
+    mustermann (2.0.2)
       ruby2_keywords (~> 0.0.1)
     oauth2 (1.4.10)
       faraday (>= 0.17.3, < 3.0)
@@ -19,14 +19,14 @@ GEM
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
     rack (2.2.3)
-    rack-protection (2.1.0)
+    rack-protection (2.2.4)
       rack
     recursive-open-struct (1.1.3)
     ruby2_keywords (0.0.5)
-    sinatra (2.1.0)
-      mustermann (~> 1.0)
+    sinatra (2.2.4)
+      mustermann (~> 2.0)
       rack (~> 2.2)
-      rack-protection (= 2.1.0)
+      rack-protection (= 2.2.4)
       tilt (~> 2.0)
     smartcar (3.3.0)
       oauth2 (~> 1.4)
@@ -35,13 +35,13 @@ GEM
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
       rack (>= 1, < 3)
-    tilt (2.0.10)
+    tilt (2.1.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  sinatra (>= 2.1.0)
+  sinatra (>= 2.2.3)
   smartcar (>= 3.3.0)
   thin (>= 1.8.1)
 

--- a/app/Gemfile.lock
+++ b/app/Gemfile.lock
@@ -1,6 +1,8 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    daemons (1.4.1)
+    eventmachine (1.2.7)
     faraday (2.4.0)
       faraday-net_http (~> 2.0)
       ruby2_keywords (>= 0.0.4)
@@ -29,6 +31,10 @@ GEM
     smartcar (3.3.0)
       oauth2 (~> 1.4)
       recursive-open-struct (~> 1.1.3)
+    thin (1.8.1)
+      daemons (~> 1.0, >= 1.0.9)
+      eventmachine (~> 1.0, >= 1.0.4)
+      rack (>= 1, < 3)
     tilt (2.0.10)
 
 PLATFORMS
@@ -37,6 +43,7 @@ PLATFORMS
 DEPENDENCIES
   sinatra (>= 2.1.0)
   smartcar (>= 3.3.0)
+  thin (>= 1.8.1)
 
 BUNDLED WITH
    2.1.2

--- a/app/app.rb
+++ b/app/app.rb
@@ -5,26 +5,26 @@ require 'smartcar'
 set :port, 8000
 
 # global variable to store the token
-@@token = ''
+$token = ''
 
 # global variable to store the client
-@@client = Smartcar::AuthClient.new({
+$client = Smartcar::AuthClient.new({
                                       mode: 'test'
                                     })
 
 get '/login' do
-  redirect @@client.get_auth_url(['required:read_vehicle_info'])
+  redirect $client.get_auth_url(['required:read_vehicle_info'])
 end
 
 get '/exchange' do
   code = params[:code]
-  @@token = @@client.exchange_code(code)[:access_token]
+  $token = $client.exchange_code(code)[:access_token]
   redirect '/vehicle'
 end
 
 get '/vehicle' do
-  vehicle_ids = Smartcar.get_vehicles(token: @@token).vehicles
-  vehicle = Smartcar::Vehicle.new(token: @@token, id: vehicle_ids.first)
+  vehicle_ids = Smartcar.get_vehicles(token: $token).vehicles
+  vehicle = Smartcar::Vehicle.new(token: $token, id: vehicle_ids.first)
   vehicle_attributes = vehicle.attributes
   vehicle_attributes.to_h.slice(*%I[id make model year]).to_json
 end

--- a/tutorial/Gemfile
+++ b/tutorial/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
-gem 'sinatra', '>= 2.1.0'
+gem 'sinatra', '>= 2.2.3'
 gem 'smartcar', '>= 3.3.0'

--- a/tutorial/Gemfile.lock
+++ b/tutorial/Gemfile.lock
@@ -8,7 +8,7 @@ GEM
     jwt (2.4.1)
     multi_json (1.15.0)
     multi_xml (0.6.0)
-    mustermann (1.1.1)
+    mustermann (2.0.2)
       ruby2_keywords (~> 0.0.1)
     oauth2 (1.4.10)
       faraday (>= 0.17.3, < 3.0)
@@ -17,25 +17,25 @@ GEM
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
     rack (2.2.3)
-    rack-protection (2.1.0)
+    rack-protection (2.2.4)
       rack
     recursive-open-struct (1.1.3)
     ruby2_keywords (0.0.5)
-    sinatra (2.1.0)
-      mustermann (~> 1.0)
+    sinatra (2.2.4)
+      mustermann (~> 2.0)
       rack (~> 2.2)
-      rack-protection (= 2.1.0)
+      rack-protection (= 2.2.4)
       tilt (~> 2.0)
     smartcar (3.3.0)
       oauth2 (~> 1.4)
       recursive-open-struct (~> 1.1.3)
-    tilt (2.0.10)
+    tilt (2.1.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  sinatra (>= 2.1.0)
+  sinatra (>= 2.2.3)
   smartcar (>= 3.3.0)
 
 BUNDLED WITH


### PR DESCRIPTION
# Summary
This PR enables `ruby 3.0` compatibility.
 
## Changes

- added `thin gem at 1.8.1`
- updated variables to global syntax. Converted  `@@ > $`
- updated README with small change



Asana: https://app.asana.com/0/1203898735752010/1204091562765652